### PR TITLE
feat: add customer email to order, fix  order tests, use native funct…

### DIFF
--- a/app/database/queries.go
+++ b/app/database/queries.go
@@ -628,9 +628,7 @@ func (db *Database) ListPayments(minDate time.Time, maxDate time.Time, vendorLic
 			log.Error(err)
 			return payments, err
 		}
-		for _, subpayment := range tmpSubPayments {
-			payment.IsPayoutFor = append(payment.IsPayoutFor, subpayment)
-		}
+		payment.IsPayoutFor = append(payment.IsPayoutFor, tmpSubPayments...)
 		payments = append(payments, payment)
 	}
 

--- a/app/database/queries.go
+++ b/app/database/queries.go
@@ -298,6 +298,23 @@ func (db *Database) GetOrderEntries(orderID int) (entries []OrderEntry, err erro
 	}
 	return
 }
+func (db *Database) GetOrderEntriesTx(tx pgx.Tx, orderID int) (entries []OrderEntry, err error) {
+	rows, err := tx.Query(context.Background(), "SELECT OrderEntry.ID, Item, Quantity, Price, Sender, Receiver, SenderAccount.Name, ReceiverAccount.Name, IsSale FROM OrderEntry JOIN Account as SenderAccount ON SenderAccount.ID = Sender JOIN Account as ReceiverAccount ON ReceiverAccount.ID = Receiver WHERE paymentorder = $1 ", orderID)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	for rows.Next() {
+		var entry OrderEntry
+		err = rows.Scan(&entry.ID, &entry.Item, &entry.Quantity, &entry.Price, &entry.Sender, &entry.Receiver, &entry.SenderName, &entry.ReceiverName, &entry.IsSale)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		entries = append(entries, entry)
+	}
+	return
+}
 
 // GetOrders returns all orders from the database
 func (db *Database) GetOrders() (orders []Order, err error) {
@@ -333,6 +350,23 @@ func (db *Database) GetOrderByID(id int) (order Order, err error) {
 
 	// Add entries to order
 	order.Entries, err = db.GetOrderEntries(order.ID)
+	if err != nil {
+		log.Error(err)
+	}
+
+	return
+}
+
+// GetOrderByIDTx returns Order by OrderID
+func (db *Database) GetOrderByIDTx(tx pgx.Tx, id int) (order Order, err error) {
+	err = tx.QueryRow(context.Background(), "SELECT * FROM PaymentOrder WHERE ID = $1", id).Scan(&order.ID, &order.OrderCode, &order.TransactionID, &order.Verified, &order.TransactionTypeID, &order.Timestamp, &order.User, &order.Vendor)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	// Add entries to order
+	order.Entries, err = db.GetOrderEntriesTx(tx, order.ID)
 	if err != nil {
 		log.Error(err)
 	}
@@ -409,8 +443,13 @@ func createOrderEntryTx(tx pgx.Tx, orderID int, entry OrderEntry) (OrderEntry, e
 // createPaymentForOrderEntryTx creates a payment for an order entry
 func createPaymentForOrderEntryTx(tx pgx.Tx, orderID int, entry OrderEntry, errorIfExists bool) (paymentID int, err error) {
 
+	// Check if payment already exists for this entry
 	var count int
 	err = tx.QueryRow(context.Background(), "SELECT COUNT(*) FROM Payment WHERE OrderEntry = $1", entry.ID).Scan(&count)
+	if err != nil {
+		log.Error(err)
+		return
+	}
 
 	// If no payment exists for this entry, create one
 	var payment Payment
@@ -441,8 +480,8 @@ func (db *Database) VerifyOrderAndCreatePayments(orderID int, transactionTypeID 
 	if err != nil {
 		return err
 	}
-	defer func() { err = deferTx(tx, err) }()
 
+	defer func() { err = deferTx(tx, err) }()
 	// Verify payment order
 	_, err = tx.Exec(context.Background(), `
 	UPDATE PaymentOrder
@@ -454,11 +493,19 @@ func (db *Database) VerifyOrderAndCreatePayments(orderID int, transactionTypeID 
 	}
 
 	// Get Paymentorder (including payments)
-	order, err := db.GetOrderByID(orderID)
+	order, err := db.GetOrderByIDTx(tx, orderID)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
 
 	// Create payments
 	for _, entry := range order.Entries {
 		_, err = createPaymentForOrderEntryTx(tx, orderID, entry, false)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
 	}
 
 	return
@@ -496,7 +543,13 @@ func (db *Database) CreatePayedOrderEntries(orderID int, entries []OrderEntry) (
 // ListPayments returns the payments from the database
 func (db *Database) ListPayments(minDate time.Time, maxDate time.Time, vendorLicenseID string, filterPayouts bool, filterSales bool, filterNoPayout bool) (payments []Payment, err error) {
 	var rows pgx.Rows
+	// Start a transaction
+	tx, err := db.Dbpool.Begin(context.Background())
+	if err != nil {
+		return nil, err
+	}
 
+	defer func() { err = deferTx(tx, err) }()
 	// Create filters
 	var filters []string
 	var filterValues []any
@@ -547,43 +600,37 @@ func (db *Database) ListPayments(minDate time.Time, maxDate time.Time, vendorLic
 	}
 
 	// Query based on parameters
-	query := "SELECT Payment.ID, Payment.Timestamp, Sender, Receiver, SenderAccount.Name, ReceiverAccount.Name, Amount, AuthorizedBy, PaymentOrder, OrderEntry, IsSale, Payout, Item, Quantity, Price FROM Payment JOIN Account as SenderAccount ON SenderAccount.ID = Sender JOIN Account as ReceiverAccount ON ReceiverAccount.ID = Receiver"
+	query := "SELECT Payment.ID, Payment.Timestamp, Sender, Receiver, SenderAccount.Name SenderName, ReceiverAccount.Name ReceiverName, Amount, AuthorizedBy, PaymentOrder, OrderEntry, IsSale, Payout, null as IsPayoutFor, Item, Quantity, Price FROM Payment JOIN Account as SenderAccount ON SenderAccount.ID = Sender JOIN Account as ReceiverAccount ON ReceiverAccount.ID = Receiver"
 	if len(filters) > 0 {
 		query += " WHERE " + strings.Join(filters, " AND ")
 	}
 	// Order by timestamp
 	query += " ORDER BY Payment.Timestamp"
-	rows, err = db.Dbpool.Query(context.Background(), query, filterValues...)
+	rows, err = tx.Query(context.Background(), query, filterValues...)
 	if err != nil {
 		log.Error(err)
 		return payments, err
 	}
+	tmpPayments, err := pgx.CollectRows(rows, pgx.RowToStructByName[Payment])
+	if err != nil {
+		log.Error(err)
+		return payments, err
+	}
+	for _, payment := range tmpPayments {
 
-	// Scan rows
-	for rows.Next() {
-		var payment Payment
-		err = rows.Scan(&payment.ID, &payment.Timestamp, &payment.Sender, &payment.Receiver, &payment.SenderName, &payment.ReceiverName, &payment.Amount, &payment.AuthorizedBy, &payment.Order, &payment.OrderEntry, &payment.IsSale, &payment.Payout, &payment.Item, &payment.Quantity, &payment.Price)
+		subrows, err := tx.Query(context.Background(), "SELECT ID, Timestamp, Sender, null as SenderName, Receiver, null as ReceiverName, Amount, AuthorizedBy, PaymentOrder, OrderEntry, IsSale, Payout, null as IsPayoutFor, Item, Quantity, Price FROM Payment WHERE Payout = $1 ORDER BY Timestamp", payment.ID)
+		if err != nil {
+			return payments, err
+		}
+		tmpSubPayments, err := pgx.CollectRows(subrows, pgx.RowToStructByName[Payment])
+		log.Error(err)
 		if err != nil {
 			log.Error(err)
 			return payments, err
 		}
-
-		// Add payout payments to main payment
-		subrows, err := db.Dbpool.Query(context.Background(), "SELECT ID, Timestamp, Sender, Receiver, Amount, AuthorizedBy, PaymentOrder, OrderEntry, IsSale, Payout, Item, Quantity, Price FROM Payment WHERE Payout = $1 ORDER BY Timestamp", payment.ID)
-		if err != nil {
-			log.Error(err)
-			return payments, err
-		}
-		for subrows.Next() {
-			var subpayment Payment
-			err = subrows.Scan(&subpayment.ID, &subpayment.Timestamp, &subpayment.Sender, &subpayment.Receiver, &subpayment.Amount, &subpayment.AuthorizedBy, &subpayment.Order, &subpayment.OrderEntry, &subpayment.IsSale, &subpayment.Payout, &subpayment.Item, &subpayment.Quantity, &subpayment.Price)
-			if err != nil {
-				log.Error(err)
-				return payments, err
-			}
+		for _, subpayment := range tmpSubPayments {
 			payment.IsPayoutFor = append(payment.IsPayoutFor, subpayment)
 		}
-
 		payments = append(payments, payment)
 	}
 

--- a/app/database/types.go
+++ b/app/database/types.go
@@ -70,6 +70,7 @@ type Order struct {
 	User              null.String // Keycloak UUID if user is authenticated
 	Vendor            int
 	Entries           []OrderEntry
+	CustomerEmail     null.String
 }
 
 // OrderEntry is a struct that is used for the order_entry table
@@ -91,16 +92,16 @@ type Payment struct {
 	Timestamp    time.Time
 	Sender       int
 	Receiver     int
-	SenderName   string // JOIN from Sender Account
-	ReceiverName string // JOIN from Receiver Account
+	SenderName   null.String // JOIN from Sender Account
+	ReceiverName null.String // JOIN from Receiver Account
 	Amount       int
 	AuthorizedBy string
-	Order        null.Int `swaggertype:"integer"`
+	Order        null.Int `swaggertype:"integer" db:"paymentorder"`
 	OrderEntry   null.Int `swaggertype:"integer"`
 	IsSale       bool
-	Payout       null.Int `swaggertype:"integer"` // Connected payout payment
-	IsPayoutFor  []Payment
-	Item         null.Int `swaggertype:"integer"`
+	Payout       null.Int  `swaggertype:"integer"` // Connected payout payment
+	IsPayoutFor  []Payment `db:"ispayoutfor"`      // Connected payout payment
+	Item         null.Int  `swaggertype:"integer"`
 	Quantity     int
 	Price        int // Price at time of purchase in cents
 }

--- a/app/handlers/handlers_test.go
+++ b/app/handlers/handlers_test.go
@@ -392,7 +392,6 @@ func TestOrders(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 	// Test order amount
 	orderTotal := order.GetTotal()
 	require.Equal(t, orderTotal, 20*2)

--- a/app/keycloak/keycloak_test.go
+++ b/app/keycloak/keycloak_test.go
@@ -41,56 +41,56 @@ func TestKeycloak(t *testing.T) {
 	role_name := "testrole"
 	err = keycloak.KeycloakClient.CreateRole(role_name)
 	if err != nil {
-		log.Error("Create role failed:", err)
+		log.Error("TestKeycloak: Create role failed:", err)
 	}
 	role, err := keycloak.KeycloakClient.GetRole(role_name)
 	if err != nil {
-		log.Error("Get role failed:", err)
+		log.Error("TestKeycloak: Get role failed:", err)
 	}
 
 	require.Equal(t, role_name, *role.Name)
 
 	_, err = keycloak.KeycloakClient.CreateUser("testuser", "testuser", "testuser@example.com", "password")
 	if err != nil {
-		log.Errorf("Create user failed: %v \n", err)
+		log.Errorf("TestKeycloak: Create user failed: %v \n", err)
 	}
 
 	user, err := keycloak.KeycloakClient.GetUser("testuser@example.com")
 	if err != nil {
-		log.Error("Get user failed:", err)
+		log.Error("TestKeycloak: Get user failed:", err)
 		panic(err)
 	}
 
 	err = keycloak.KeycloakClient.AssignRole(*user.ID, role_name)
 	if err != nil {
-		log.Error("Assign role failed:", err)
+		log.Error("TestKeycloak: Assign role failed:", err)
 	}
 
 	roles, err := keycloak.KeycloakClient.GetUserRoles(*user.ID)
 	if err != nil {
-		log.Error("Get user failed:", err)
+		log.Error("TestKeycloak: Get user failed:", err)
 	}
 	require.NotNil(t, lookupRole(role_name, roles))
 
 	err = keycloak.KeycloakClient.UnassignRole(*user.ID, role_name)
 	if err != nil {
-		log.Error("Unassign role failed:", err)
+		log.Error("TestKeycloak: Unassign role failed:", err)
 	}
 
 	roles, err = keycloak.KeycloakClient.GetUserRoles(*user.ID)
 	if err != nil {
-		log.Error("Get user failed:", err)
+		log.Error("TestKeycloak: Get user failed:", err)
 	}
 	require.Nil(t, lookupRole(role_name, roles))
 
 	err = keycloak.KeycloakClient.DeleteUser(*user.ID)
 	if err != nil {
-		log.Error("Delete user failed:", err)
+		log.Error("TestKeycloak: Delete user failed:", err)
 	}
 
 	err = keycloak.KeycloakClient.DeleteRole(role_name)
 	if err != nil {
-		log.Error("Delete role failed:", err)
+		log.Error("TestKeycloak: Delete role failed:", err)
 	}
 
 }

--- a/app/migrations/004_add_CustomerEmail.sql
+++ b/app/migrations/004_add_CustomerEmail.sql
@@ -1,0 +1,12 @@
+-- Write your migrate up statements here
+
+ALTER TABLE OrderEntry ADD COLUMN CustomerEmail varchar(255);
+
+
+---- create above / drop below ----
+
+ALTER TABLE OrderEntry DROP COLUMN CustomerEmail;
+
+
+-- Write your migrate down statements here. If this migration is irreversible
+-- Then delete the separator line above.

--- a/app/migrations/004_add_CustomerEmail.sql
+++ b/app/migrations/004_add_CustomerEmail.sql
@@ -1,11 +1,11 @@
 -- Write your migrate up statements here
 
-ALTER TABLE OrderEntry ADD COLUMN CustomerEmail varchar(255);
+ALTER TABLE PaymentOrder ADD COLUMN CustomerEmail varchar(255);
 
 
 ---- create above / drop below ----
 
-ALTER TABLE OrderEntry DROP COLUMN CustomerEmail;
+ALTER TABLE PaymentOrder DROP COLUMN CustomerEmail;
 
 
 -- Write your migrate down statements here. If this migration is irreversible


### PR DESCRIPTION
…ions in ListPayments and allow empty strings for subpayment.ReceiverName,  Avoid using DB outside the current connection in VerifyOrderAndCreatePayments

# Type of change

<!-- Please delete options that are not relevant. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->

This is a first step for the digital license backend customer part. But actually it's fixing a lot of things that have to be solved on the way.

**IMPORTANT TO KNOW**
<!-- Let your reviewer know if she has to configure something new or somehting has to be thought further or ... -->

When i was enabling the order tests again, it took forever, because the requests were blocking themself. So i replaced the calls to the database without a pgx.Tx to one with pgx.Tx and i had to change the get payments, too.

There is still the code missing to create the customer in keycloak, because we don't have the keycloak group the user should be added to for the current newspaper number in order to give access in wordpress. 
Also I think this pr is already quite complex to review so i will solve the other problems with customers in a follow up pr.

**CHANGES**
<!-- Let your reviewer know what changes happened in this PR ... -->
* add customer email to order and require an email for all license items
* fix order tests, 
* the item creation in the tests had to be appended in order to get a custom name, because the item with a license and the item without had the same name, which doesn't work, when they are used in the same test
* use native functions in ListPayments and 
* allow empty strings for subpayment.ReceiverName,  
* Avoid using DB outside the current connection in VerifyOrderAndCreatePayments -> this maybe fixes our deadlocks

** to think on **
The order code for orders in the tests shouldn't be `0` for all orders. We need a way to distinguish them in order to start parallel/fast tests.

**TODO**
<!-- Let your reviewer know if there is still something to do or has to be done in the future i.e. for fine-tuning ... -->


# Checklist:

- [x] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings, neither in my IDE nor in my browser
- [x] I have added tests that prove my fix is effective or that my feature works