### PR TITLE
Add item type to Flour payment payload

### DIFF
--- a/app/integrations/flour.go
+++ b/app/integrations/flour.go
@@ -102,6 +102,7 @@ type FlourPayloadItem struct {
 	Quantity int    `json:"quantity"`
 	Price    int    `json:"price"`
 	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
 }
 
 func SendPaymentToFlour(id int, timestamp time.Time, items []database.OrderEntry, vendor database.Vendor, price int) error {
@@ -119,10 +120,12 @@ func SendPaymentToFlour(id int, timestamp time.Time, items []database.OrderEntry
 		totalPrice += itemPrice * item.Quantity
 
 		itemName := ""
+		itemType := ""
 		if dbItem, err := getItemByID(item.Item); err != nil {
 			log.Errorf("SendPaymentToFlour: Failed to fetch item name for item %d: %v", item.Item, err)
 		} else {
 			itemName = dbItem.Name
+			itemType = dbItem.Type
 		}
 
 		flourItems = append(flourItems, FlourPayloadItem{
@@ -130,6 +133,7 @@ func SendPaymentToFlour(id int, timestamp time.Time, items []database.OrderEntry
 			Quantity: item.Quantity,
 			Price:    itemPrice,
 			Name:     itemName,
+			Type:     itemType,
 		})
 	}
 	// Create a new payload


### PR DESCRIPTION
# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Description

**IMPORTANT TO KNOW**

No configuration changes required.

**CHANGES**

Added `type` field to `FlourPayloadItem` so the item type (e.g. `normal_item`, `issue`, `online_issue`, `abonement`, `donation`, `transaction_costs`, `license_item`) is included in the JSON payload sent to the Flour webhook. The value is fetched from the database alongside the existing item name lookup.

**TODO**

Nothing.

# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works