### PR TITLE
Split flour integration into separate flour and odoo plugins

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -47,6 +47,8 @@ type config struct {
 	SentryDSN                         string
 	FlourWebhookURL                   string
 	FlourWebhookToken                 string
+	OdooWebhookURL                    string
+	OdooWebhookToken                  string
 	DEBUG_payments                    bool // For debugging purposes, not used in production
 }
 
@@ -97,6 +99,8 @@ func InitConfig() error {
 		SentryDSN:                         getEnv("SENTRY_DSN", ""),
 		FlourWebhookURL:                   getEnv("FLOUR_WEBHOOK_URL", ""),
 		FlourWebhookToken:                 getEnv("FLOUR_WEBHOOK_TOKEN", ""),
+		OdooWebhookURL:                    getEnv("ODOO_WEBHOOK_URL", ""),
+		OdooWebhookToken:                  getEnv("ODOO_WEBHOOK_TOKEN", ""),
 		DEBUG_payments:                    (getEnv("DEBUG_payments", "false") == "true"),
 	}
 	return nil

--- a/app/handlers/handlers_flour_resend.go
+++ b/app/handlers/handlers_flour_resend.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/augustin-wien/augustina-backend/config"
 	"github.com/augustin-wien/augustina-backend/database"
 	"github.com/augustin-wien/augustina-backend/integrations"
 	"github.com/go-chi/chi/v5"
@@ -18,8 +20,8 @@ type resendResponse struct {
 	SentAt  string `json:"sent_at"`
 }
 
-// ResendFlourWebhook triggers resending the Flour webhook for a given order ID.
-func ResendFlourWebhook(w http.ResponseWriter, r *http.Request) {
+// ResendOdooWebhook triggers resending the Odoo webhook for a given order ID.
+func ResendOdooWebhook(w http.ResponseWriter, r *http.Request) {
 	orderIDStr := chi.URLParam(r, "orderID")
 	orderID, err := strconv.Atoi(orderIDStr)
 	if err != nil || orderID <= 0 {
@@ -39,19 +41,31 @@ func ResendFlourWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Compute total sum consistent with integrations.SendPaymentToFlour logic
 	totalSum := 0
 	for _, item := range order.Entries {
 		itemPrice := item.Price
-		if item.Receiver != vendor.ID {
+		if item.Receiver <= 5 {
 			itemPrice = -itemPrice
 		}
 		totalSum += itemPrice * item.Quantity
 	}
 
-	// Send webhook
-	if err := integrations.SendPaymentToFlour(order.ID, order.Timestamp, order.Entries, vendor, totalSum); err != nil {
-		http.Error(w, "failed to send webhook", http.StatusBadGateway)
+	var errs []error
+
+	if config.Config.FlourWebhookURL != "" {
+		if err := integrations.SendPaymentToFlour(order.ID, order.Timestamp, order.Entries, vendor, totalSum); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if config.Config.OdooWebhookURL != "" {
+		if err := integrations.SendPaymentToOdoo(order.ID, order.Timestamp, order.Entries, vendor, totalSum); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		http.Error(w, errors.Join(errs...).Error(), http.StatusBadGateway)
 		return
 	}
 

--- a/app/handlers/router.go
+++ b/app/handlers/router.go
@@ -128,7 +128,7 @@ func GetRouter() (r *chi.Mux) {
 		r.Handle("/docs/*", http.StripPrefix("/docs/", fsDocs))
 	}
 
-	// Flour integration - NO strict security middlewares (BlockBadUserAgents, BlockFakeBrowsers, BlockMaliciousPatterns)
+	// Flour integration (legacy) - NO strict security middlewares
 	// to allow external software like Flour to communicate without being blocked
 	if config.Config.FlourWebhookURL != "" {
 		log.Infof("Flour integration enabled: %s", config.Config.FlourWebhookURL)
@@ -136,6 +136,31 @@ func GetRouter() (r *chi.Mux) {
 		r.Route("/api/flour", func(r chi.Router) {
 			r.Use(middlewares.AuthMiddleware)
 			r.Use(middlewares.FlourAuthMiddleware)
+			r.Route("/vendors", func(r chi.Router) {
+
+				r.Put("/license/{licenseID}/", UpdateVendorByLicenseID)
+				r.Get("/license/{licenseID}/", GetVendorByLicenseID)
+
+				r.Put("/{id}/", UpdateVendor)
+				r.Delete("/{id}/", DeleteVendor)
+				r.Get("/{id}/", GetVendor)
+				r.Post("/", CreateVendor)
+
+			})
+			r.Route("/payments", func(r chi.Router) {
+				r.Post("/payout/", CreatePaymentPayout)
+			})
+		})
+	}
+
+	// Odoo integration - NO strict security middlewares (BlockBadUserAgents, BlockFakeBrowsers, BlockMaliciousPatterns)
+	// to allow external software like Odoo to communicate without being blocked
+	if config.Config.OdooWebhookURL != "" {
+		log.Infof("Odoo integration enabled: %s", config.Config.OdooWebhookURL)
+
+		r.Route("/api/odoo", func(r chi.Router) {
+			r.Use(middlewares.AuthMiddleware)
+			r.Use(middlewares.OdooAuthMiddleware)
 			r.Route("/vendors", func(r chi.Router) {
 
 				r.Put("/license/{licenseID}/", UpdateVendorByLicenseID)
@@ -257,7 +282,7 @@ func GetRouter() (r *chi.Mux) {
 				r.Get("/unverified/", ListUnverifiedOrders)
 				r.Get("/unverified/code/{orderCode}/verify/", AdminVerifyPaymentOrderByCode)
 				r.Post("/unverified/code/{orderCode}/transactionID/", AdminAddTransactionIDToOrder)
-				r.Post("/resend/{orderID}/", ResendFlourWebhook)
+				r.Post("/resend/{orderID}/", ResendOdooWebhook)
 			})
 		})
 

--- a/app/integrations/flour.go
+++ b/app/integrations/flour.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"time"
 
 	"github.com/augustin-wien/augustina-backend/config"
@@ -57,15 +56,6 @@ func sendJSONToFlourWebhook(payload interface{}) error {
 			return fmt.Errorf("failed to create request: %v", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-Odoo-Database", "huk_odoo19")
-		if token := config.Config.FlourWebhookToken; token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
-			log.Debug("sendJSONToFlourWebhook: Added Authorization header to request")
-		}
-
-		if dump, dumpErr := httputil.DumpRequestOut(req, true); dumpErr == nil {
-			log.Debugf("sendJSONToFlourWebhook: HTTP request:\n%s", string(dump))
-		}
 
 		// Send the request
 		client := &http.Client{}
@@ -73,15 +63,11 @@ func sendJSONToFlourWebhook(payload interface{}) error {
 		if err != nil {
 			log.Errorf("sendJSONToFlourWebhook: Request failed: %v\n", err)
 		} else {
-			resp.Body.Close()
+			defer resp.Body.Close()
 
+			// Check for 200 OK status
 			if resp.StatusCode == http.StatusOK || resp.StatusCode == 201 {
 				log.Info("sendJSONToFlourWebhook: Successfully sent flour JSON payload")
-				return nil
-			}
-
-			if resp.StatusCode == http.StatusUnprocessableEntity {
-				log.Infof("sendJSONToFlourWebhook: Received 422 Unprocessable Entity, treating as non-fatal")
 				return nil
 			}
 
@@ -116,7 +102,6 @@ type FlourPayloadItem struct {
 	Quantity int    `json:"quantity"`
 	Price    int    `json:"price"`
 	Name     string `json:"name,omitempty"`
-	Type     string `json:"type,omitempty"`
 }
 
 func SendPaymentToFlour(id int, timestamp time.Time, items []database.OrderEntry, vendor database.Vendor, price int) error {
@@ -134,27 +119,17 @@ func SendPaymentToFlour(id int, timestamp time.Time, items []database.OrderEntry
 		totalPrice += itemPrice * item.Quantity
 
 		itemName := ""
-		itemType := ""
 		if dbItem, err := getItemByID(item.Item); err != nil {
 			log.Errorf("SendPaymentToFlour: Failed to fetch item name for item %d: %v", item.Item, err)
 		} else {
 			itemName = dbItem.Name
-			itemType = dbItem.Type
-		}
-
-		flourQuantity := item.Quantity
-		flourPrice := itemPrice
-		if itemType == "donation" {
-			flourPrice = itemPrice * item.Quantity
-			flourQuantity = 1
 		}
 
 		flourItems = append(flourItems, FlourPayloadItem{
 			ID:       item.Item,
-			Quantity: flourQuantity,
-			Price:    flourPrice,
+			Quantity: item.Quantity,
+			Price:    itemPrice,
 			Name:     itemName,
-			Type:     itemType,
 		})
 	}
 	// Create a new payload

--- a/app/integrations/odoo.go
+++ b/app/integrations/odoo.go
@@ -1,0 +1,151 @@
+package integrations
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"time"
+
+	"github.com/augustin-wien/augustina-backend/config"
+	"github.com/augustin-wien/augustina-backend/database"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+func sendJSONToOdooWebhook(payload interface{}) error {
+	endpoint := config.Config.OdooWebhookURL
+
+	log.Debugf("sendJSONToOdooWebhook: Sending payload to Odoo webhook: %+v", payload)
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %v", err)
+	}
+
+	var retryCount int
+	backoff := initialBackoff
+
+	for {
+		req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonData))
+		if err != nil {
+			log.Errorf("sendJSONToOdooWebhook: Failed to create request: %v\n", err)
+			return fmt.Errorf("failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Odoo-Database", "huk_odoo19")
+		if token := config.Config.OdooWebhookToken; token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+			log.Debug("sendJSONToOdooWebhook: Added Authorization header to request")
+		}
+
+		if dump, dumpErr := httputil.DumpRequestOut(req, true); dumpErr == nil {
+			log.Debugf("sendJSONToOdooWebhook: HTTP request:\n%s", string(dump))
+		}
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Errorf("sendJSONToOdooWebhook: Request failed: %v\n", err)
+		} else {
+			resp.Body.Close()
+
+			if resp.StatusCode == http.StatusOK || resp.StatusCode == 201 {
+				log.Info("sendJSONToOdooWebhook: Successfully sent Odoo JSON payload")
+				return nil
+			}
+
+			if resp.StatusCode == http.StatusUnprocessableEntity {
+				log.Infof("sendJSONToOdooWebhook: Received 422 Unprocessable Entity, treating as non-fatal")
+				return nil
+			}
+
+			log.Infof("sendJSONToOdooWebhook: Received non-200 response: %d\n", resp.StatusCode)
+		}
+
+		if retryCount >= maxRetries {
+			return errors.New("exceeded maximum retries, aborting")
+		}
+
+		retryCount++
+		log.Infof("Retrying in %v... (attempt %d)\n", backoff, retryCount)
+		time.Sleep(backoff)
+
+		backoff *= 2
+	}
+}
+
+type OdooPayload struct {
+	OrderID   int               `json:"order_id"`
+	Price     int               `json:"price"`
+	LicenseID null.String       `json:"license_id"`
+	Timestamp time.Time         `json:"timestamp"`
+	Items     []OdooPayloadItem `json:"items"`
+}
+
+type OdooPayloadItem struct {
+	ID       int    `json:"id"`
+	Quantity int    `json:"quantity"`
+	Price    int    `json:"price"`
+	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
+}
+
+func SendPaymentToOdoo(id int, timestamp time.Time, items []database.OrderEntry, vendor database.Vendor, price int) error {
+	log.Info("SendPaymentToOdoo: Sending payment to Odoo for order ", id)
+	odooItems := make([]OdooPayloadItem, 0)
+	totalPrice := 0
+	for _, item := range items {
+		itemPrice := item.Price
+		log.Debugf("SendPaymentToOdoo: Processing item %+v for vendor %+v", item, vendor)
+		if item.Receiver <= 5 {
+			itemPrice = -itemPrice
+		}
+		totalPrice += itemPrice * item.Quantity
+
+		itemName := ""
+		itemType := ""
+		if dbItem, err := getItemByID(item.Item); err != nil {
+			log.Errorf("SendPaymentToOdoo: Failed to fetch item name for item %d: %v", item.Item, err)
+		} else {
+			itemName = dbItem.Name
+			itemType = dbItem.Type
+		}
+
+		odooQuantity := item.Quantity
+		odooPrice := itemPrice
+		if itemType == "donation" {
+			odooPrice = itemPrice * item.Quantity
+			odooQuantity = 1
+		}
+
+		odooItems = append(odooItems, OdooPayloadItem{
+			ID:       item.Item,
+			Quantity: odooQuantity,
+			Price:    odooPrice,
+			Name:     itemName,
+			Type:     itemType,
+		})
+	}
+	payload := OdooPayload{
+		OrderID:   id,
+		Price:     totalPrice,
+		LicenseID: vendor.LicenseID,
+		Timestamp: timestamp,
+		Items:     odooItems,
+	}
+	payloadJSON, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		log.Errorf("SendPaymentToOdoo: Failed to marshal payload to JSON: %v", err)
+	} else {
+		log.Debugf("SendPaymentToOdoo: Payload JSON:\n%s", string(payloadJSON))
+	}
+
+	err = sendJSONToOdooWebhook(payload)
+	if err != nil {
+		log.Errorf("Failed to send JSON to Odoo: %v\n", err)
+	}
+	return err
+}

--- a/app/integrations/odoo_test.go
+++ b/app/integrations/odoo_test.go
@@ -14,9 +14,8 @@ import (
 	"gopkg.in/guregu/null.v4"
 )
 
-// TestSendPaymentToFlourSuccess tests successful payment sending to Flour webhook
-func TestSendPaymentToFlourSuccess(t *testing.T) {
-	// Mock getItemByID
+// TestSendPaymentToOdooSuccess tests successful payment sending to Odoo webhook
+func TestSendPaymentToOdooSuccess(t *testing.T) {
 	originalGetItemByID := getItemByID
 	getItemByID = func(id int) (database.Item, error) {
 		return database.Item{
@@ -26,20 +25,15 @@ func TestSendPaymentToFlourSuccess(t *testing.T) {
 	}
 	defer func() { getItemByID = originalGetItemByID }()
 
-	// Create a mock server to capture the webhook request
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify request method and headers
 		require.Equal(t, "POST", r.Method)
 		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
-		// Parse the incoming payload
-		var receivedPayload FlourPayload
+		var receivedPayload OdooPayload
 		err := json.NewDecoder(r.Body).Decode(&receivedPayload)
 		require.NoError(t, err)
 
-		// Verify payload structure
 		require.Equal(t, 123, receivedPayload.OrderID)
-		// Total price: (2500 * 2) + (2500 * 1) = 7500
 		require.Equal(t, 7500, receivedPayload.Price)
 		require.Equal(t, "test-license-123", receivedPayload.LicenseID.String)
 		require.Len(t, receivedPayload.Items, 2)
@@ -52,18 +46,15 @@ func TestSendPaymentToFlourSuccess(t *testing.T) {
 		require.Equal(t, 2500, receivedPayload.Items[1].Price)
 		require.Equal(t, "Test Item", receivedPayload.Items[1].Name)
 
-		// Return successful response
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok"}`))
 	}))
 	defer mockServer.Close()
 
-	// Set the webhook URL to our mock server
-	originalURL := config.Config.FlourWebhookURL
-	config.Config.FlourWebhookURL = mockServer.URL
-	defer func() { config.Config.FlourWebhookURL = originalURL }()
+	originalURL := config.Config.OdooWebhookURL
+	config.Config.OdooWebhookURL = mockServer.URL
+	defer func() { config.Config.OdooWebhookURL = originalURL }()
 
-	// Create test data
 	timestamp := time.Date(2025, 12, 10, 14, 30, 0, 0, time.UTC)
 	items := []database.OrderEntry{
 		{
@@ -71,14 +62,14 @@ func TestSendPaymentToFlourSuccess(t *testing.T) {
 			Item:     1,
 			Quantity: 2,
 			Price:    2500,
-			Receiver: 6234, // Set to vendor ID for positive price
+			Receiver: 6234,
 		},
 		{
 			ID:       2,
 			Item:     2,
 			Quantity: 1,
 			Price:    2500,
-			Receiver: 6234, // Set to vendor ID for positive price
+			Receiver: 6234,
 		},
 	}
 	vendor := database.Vendor{
@@ -89,20 +80,17 @@ func TestSendPaymentToFlourSuccess(t *testing.T) {
 		LicenseID: null.StringFrom("test-license-123"),
 	}
 
-	// Call the function
-	// Total price: (2500 * 2) + (2500 * 1) = 5000 + 2500 = 7500
-	err := SendPaymentToFlour(123, timestamp, items, vendor, 7500)
+	err := SendPaymentToOdoo(123, timestamp, items, vendor, 7500)
 	require.NoError(t, err)
 }
 
-// TestSendPaymentToFlourEmptyItems tests sending payment with empty items list
-func TestSendPaymentToFlourEmptyItems(t *testing.T) {
+// TestSendPaymentToOdooEmptyItems tests sending payment with empty items list
+func TestSendPaymentToOdooEmptyItems(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var receivedPayload FlourPayload
+		var receivedPayload OdooPayload
 		err := json.NewDecoder(r.Body).Decode(&receivedPayload)
 		require.NoError(t, err)
 
-		// Verify empty items
 		require.Len(t, receivedPayload.Items, 0)
 		require.Equal(t, 456, receivedPayload.OrderID)
 
@@ -111,9 +99,9 @@ func TestSendPaymentToFlourEmptyItems(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	originalURL := config.Config.FlourWebhookURL
-	config.Config.FlourWebhookURL = mockServer.URL
-	defer func() { config.Config.FlourWebhookURL = originalURL }()
+	originalURL := config.Config.OdooWebhookURL
+	config.Config.OdooWebhookURL = mockServer.URL
+	defer func() { config.Config.OdooWebhookURL = originalURL }()
 
 	timestamp := time.Now()
 	vendor := database.Vendor{
@@ -121,13 +109,12 @@ func TestSendPaymentToFlourEmptyItems(t *testing.T) {
 		LicenseID: null.StringFrom("test-license-456"),
 	}
 
-	err := SendPaymentToFlour(456, timestamp, []database.OrderEntry{}, vendor, 1000)
+	err := SendPaymentToOdoo(456, timestamp, []database.OrderEntry{}, vendor, 1000)
 	require.NoError(t, err)
 }
 
-// TestSendPaymentToFlourWithNullLicenseID tests sending payment with null license ID
-func TestSendPaymentToFlourWithNullLicenseID(t *testing.T) {
-	// Mock getItemByID
+// TestSendPaymentToOdooWithNullLicenseID tests sending payment with null license ID
+func TestSendPaymentToOdooWithNullLicenseID(t *testing.T) {
 	originalGetItemByID := getItemByID
 	getItemByID = func(id int) (database.Item, error) {
 		return database.Item{
@@ -138,11 +125,10 @@ func TestSendPaymentToFlourWithNullLicenseID(t *testing.T) {
 	defer func() { getItemByID = originalGetItemByID }()
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var receivedPayload FlourPayload
+		var receivedPayload OdooPayload
 		err := json.NewDecoder(r.Body).Decode(&receivedPayload)
 		require.NoError(t, err)
 
-		// Verify license ID is null
 		require.False(t, receivedPayload.LicenseID.Valid)
 		require.Equal(t, 789, receivedPayload.OrderID)
 
@@ -151,9 +137,9 @@ func TestSendPaymentToFlourWithNullLicenseID(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	originalURL := config.Config.FlourWebhookURL
-	config.Config.FlourWebhookURL = mockServer.URL
-	defer func() { config.Config.FlourWebhookURL = originalURL }()
+	originalURL := config.Config.OdooWebhookURL
+	config.Config.OdooWebhookURL = mockServer.URL
+	defer func() { config.Config.OdooWebhookURL = originalURL }()
 
 	timestamp := time.Now()
 	items := []database.OrderEntry{
@@ -162,49 +148,20 @@ func TestSendPaymentToFlourWithNullLicenseID(t *testing.T) {
 			Item:     1,
 			Quantity: 1,
 			Price:    3000,
-			Receiver: 6236, // Vendor ID
+			Receiver: 6236,
 		},
 	}
 	vendor := database.Vendor{
 		ID:        6236,
-		LicenseID: null.String{}, // null license ID
+		LicenseID: null.String{},
 	}
 
-	err := SendPaymentToFlour(789, timestamp, items, vendor, 3000)
+	err := SendPaymentToOdoo(789, timestamp, items, vendor, 3000)
 	require.NoError(t, err)
 }
 
-// TestSendPaymentToFlourConnectionError tests handling of connection errors
-// func TestSendPaymentToFlourConnectionError(t *testing.T) {
-// 	// Use an invalid URL that will cause connection errors
-// 	originalURL := config.Config.FlourWebhookURL
-// 	config.Config.FlourWebhookURL = "http://invalid-url"
-// 	defer func() { config.Config.FlourWebhookURL = originalURL }()
-
-// 	timestamp := time.Now()
-// 	items := []database.OrderEntry{
-// 		{
-// 			ID:       1,
-// 			Item:     1,
-// 			Quantity: 1,
-// 			Price:    5000,
-// 			Receiver: 6237, // Vendor ID
-// 		},
-// 	}
-// 	vendor := database.Vendor{
-// 		ID:        6237,
-// 		LicenseID: null.StringFrom("test-license-789"),
-// 	}
-
-// 	// Should return an error after retries
-// 	err := SendPaymentToFlour(999, timestamp, items, vendor, 5000)
-// 	require.Error(t, err)
-// 	require.Contains(t, err.Error(), "exceeded maximum retries")
-// }
-
-// TestSendPaymentToFlourMultipleItems tests sending payment with multiple items
-func TestSendPaymentToFlourMultipleItems(t *testing.T) {
-	// Mock getItemByID
+// TestSendPaymentToOdooMultipleItems tests sending payment with multiple items
+func TestSendPaymentToOdooMultipleItems(t *testing.T) {
 	originalGetItemByID := getItemByID
 	getItemByID = func(id int) (database.Item, error) {
 		return database.Item{
@@ -215,27 +172,25 @@ func TestSendPaymentToFlourMultipleItems(t *testing.T) {
 	defer func() { getItemByID = originalGetItemByID }()
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var receivedPayload FlourPayload
+		var receivedPayload OdooPayload
 		err := json.NewDecoder(r.Body).Decode(&receivedPayload)
 		require.NoError(t, err)
 
-		// Verify multiple items
 		require.Len(t, receivedPayload.Items, 5)
 		for i := 0; i < 5; i++ {
 			require.Equal(t, i+1, receivedPayload.Items[i].ID)
 		}
 		require.Equal(t, 555, receivedPayload.OrderID)
-		// Price should be: (3000*3) + (3000*2) + (3000*2) + (3000*1) + (3000*1) = 9000 + 6000 + 6000 + 3000 + 3000 = 27000
 		require.Equal(t, 27000, receivedPayload.Price)
 
-		w.WriteHeader(http.StatusCreated) // Test with 201 Created status as well
+		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte(`{"status":"created"}`))
 	}))
 	defer mockServer.Close()
 
-	originalURL := config.Config.FlourWebhookURL
-	config.Config.FlourWebhookURL = mockServer.URL
-	defer func() { config.Config.FlourWebhookURL = originalURL }()
+	originalURL := config.Config.OdooWebhookURL
+	config.Config.OdooWebhookURL = mockServer.URL
+	defer func() { config.Config.OdooWebhookURL = originalURL }()
 
 	timestamp := time.Date(2025, 12, 10, 15, 45, 30, 0, time.UTC)
 	items := []database.OrderEntry{
@@ -250,14 +205,12 @@ func TestSendPaymentToFlourMultipleItems(t *testing.T) {
 		LicenseID: null.StringFrom("test-license-555"),
 	}
 
-	// Price should be: (3000*3) + (3000*2) + (3000*2) + (3000*1) + (3000*1) = 27000
-	err := SendPaymentToFlour(555, timestamp, items, vendor, 27000)
+	err := SendPaymentToOdoo(555, timestamp, items, vendor, 27000)
 	require.NoError(t, err)
 }
 
-// TestSendPaymentToFlourPayloadStructure tests that payload structure is correct
-func TestSendPaymentToFlourPayloadStructure(t *testing.T) {
-	// Mock getItemByID
+// TestSendPaymentToOdooPayloadStructure tests that payload structure is correct
+func TestSendPaymentToOdooPayloadStructure(t *testing.T) {
 	originalGetItemByID := getItemByID
 	getItemByID = func(id int) (database.Item, error) {
 		return database.Item{
@@ -278,9 +231,9 @@ func TestSendPaymentToFlourPayloadStructure(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	originalURL := config.Config.FlourWebhookURL
-	config.Config.FlourWebhookURL = mockServer.URL
-	defer func() { config.Config.FlourWebhookURL = originalURL }()
+	originalURL := config.Config.OdooWebhookURL
+	config.Config.OdooWebhookURL = mockServer.URL
+	defer func() { config.Config.OdooWebhookURL = originalURL }()
 
 	timestamp := time.Date(2025, 12, 10, 16, 0, 0, 0, time.UTC)
 	items := []database.OrderEntry{
@@ -291,17 +244,14 @@ func TestSendPaymentToFlourPayloadStructure(t *testing.T) {
 		LicenseID: null.StringFrom("structure-test-license"),
 	}
 
-	err := SendPaymentToFlour(666, timestamp, items, vendor, 2000)
+	err := SendPaymentToOdoo(666, timestamp, items, vendor, 2000)
 	require.NoError(t, err)
 
-	// Verify the captured payload is valid JSON
-	var payload FlourPayload
+	var payload OdooPayload
 	err = json.Unmarshal(capturedPayload, &payload)
 	require.NoError(t, err)
 
-	// Verify all fields are present and correct
 	require.Equal(t, 666, payload.OrderID)
-	// Price should be sum of items: 1 item * 2000 = 2000
 	require.Equal(t, 2000, payload.Price)
 	require.Equal(t, "structure-test-license", payload.LicenseID.String)
 	require.True(t, payload.Timestamp.Equal(timestamp))
@@ -311,30 +261,32 @@ func TestSendPaymentToFlourPayloadStructure(t *testing.T) {
 	require.Equal(t, 2000, payload.Items[0].Price)
 }
 
-// TestSendPaymentToFlourDonationWithMultipleQuantities tests 100 cents donation with multiple items and quantities
-func TestSendPaymentToFlourDonationWithMultipleQuantities(t *testing.T) {
-	// Mock getItemByID
+// TestSendPaymentToOdooDonationWithMultipleQuantities tests that a donation item is sent as quantity=1
+// with the full price, instead of 200x 1-cent entries.
+func TestSendPaymentToOdooDonationWithMultipleQuantities(t *testing.T) {
 	originalGetItemByID := getItemByID
 	getItemByID = func(id int) (database.Item, error) {
+		itemType := "normal_item"
+		if id == 2 {
+			itemType = "donation"
+		}
 		return database.Item{
 			ID:   id,
 			Name: "Test Item",
+			Type: itemType,
 		}, nil
 	}
 	defer func() { getItemByID = originalGetItemByID }()
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var receivedPayload FlourPayload
+		var receivedPayload OdooPayload
 		err := json.NewDecoder(r.Body).Decode(&receivedPayload)
 		require.NoError(t, err)
 
-		// Verify payload for donation scenario
 		require.Equal(t, 777, receivedPayload.OrderID)
-		// Price should be: (50*5) + (-100*1) + (-50*1) = 250 - 100 - 50 = 100 cents
 		require.Equal(t, 100, receivedPayload.Price)
 		require.Equal(t, "donation-license-123", receivedPayload.LicenseID.String)
 
-		// Verify items with different quantities
 		require.Len(t, receivedPayload.Items, 3)
 
 		// Item 1: Magazine (quantity 5, price 50 cents each)
@@ -342,10 +294,10 @@ func TestSendPaymentToFlourDonationWithMultipleQuantities(t *testing.T) {
 		require.Equal(t, 5, receivedPayload.Items[0].Quantity)
 		require.Equal(t, 50, receivedPayload.Items[0].Price)
 
-		// Item 2: Donation to charity (quantity 1, price -100 cents, receiver is charity not vendor)
+		// Item 2: Donation to charity — collapsed to quantity=1 with full price
 		require.Equal(t, 2, receivedPayload.Items[1].ID)
-		require.Equal(t, 100, receivedPayload.Items[1].Quantity)
-		require.Equal(t, -1, receivedPayload.Items[1].Price)
+		require.Equal(t, 1, receivedPayload.Items[1].Quantity)
+		require.Equal(t, -100, receivedPayload.Items[1].Price)
 
 		// Item 3: Service fee (quantity 1, price -50 cents, receiver is not vendor)
 		require.Equal(t, 3, receivedPayload.Items[2].ID)
@@ -357,32 +309,32 @@ func TestSendPaymentToFlourDonationWithMultipleQuantities(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	originalURL := config.Config.FlourWebhookURL
-	config.Config.FlourWebhookURL = mockServer.URL
-	defer func() { config.Config.FlourWebhookURL = originalURL }()
+	originalURL := config.Config.OdooWebhookURL
+	config.Config.OdooWebhookURL = mockServer.URL
+	defer func() { config.Config.OdooWebhookURL = originalURL }()
 
 	timestamp := time.Date(2025, 12, 12, 10, 30, 0, 0, time.UTC)
 	items := []database.OrderEntry{
 		{
 			ID:       1,
-			Item:     1, // Magazine
+			Item:     1,
 			Quantity: 5,
-			Price:    50,   // 50 cents each
-			Receiver: 6240, // Vendor receives this
+			Price:    50,
+			Receiver: 6240,
 		},
 		{
 			ID:       2,
-			Item:     2, // Donation to charity
+			Item:     2,
 			Quantity: 100,
-			Price:    1, // 100 cents donation
-			Receiver: 1, // Charity receives this (not vendor, so negated)
+			Price:    1,
+			Receiver: 1,
 		},
 		{
 			ID:       3,
-			Item:     3, // Service fee
+			Item:     3,
 			Quantity: 1,
-			Price:    50, // 50 cents service fee
-			Receiver: 2,  // Platform receives this (not vendor, so negated)
+			Price:    50,
+			Receiver: 2,
 		},
 	}
 	vendor := database.Vendor{
@@ -393,7 +345,6 @@ func TestSendPaymentToFlourDonationWithMultipleQuantities(t *testing.T) {
 		LicenseID: null.StringFrom("donation-license-123"),
 	}
 
-	// Total price: (50*5) + (-100*1) + (-50*1) = 250 - 100 - 50 = 100 cents
-	err := SendPaymentToFlour(777, timestamp, items, vendor, 100)
+	err := SendPaymentToOdoo(777, timestamp, items, vendor, 100)
 	require.NoError(t, err)
 }

--- a/app/middlewares/middleware.go
+++ b/app/middlewares/middleware.go
@@ -38,6 +38,7 @@ func AuthMiddleware(next http.Handler) http.Handler {
 		r.Header.Del("X-Auth-Roles-vendor")
 		r.Header.Del("X-Auth-Roles-admin")
 		r.Header.Del("X-Auth-Roles-flour")
+		r.Header.Del("X-Auth-Roles-odoo")
 		r.Header.Del("X-Auth-Groups-Vendors")
 		r.Header.Del("X-Auth-Groups-Admins")
 
@@ -155,7 +156,7 @@ func CustomerAuthMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// FlourAuthMiddleware is a middleware to check if the request is authorized as admin
+// FlourAuthMiddleware checks that the request carries the flour role.
 func FlourAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -172,6 +173,31 @@ func FlourAuthMiddleware(next http.Handler) http.Handler {
 		}
 		if r.Header.Get("X-Auth-Roles-flour") == "" {
 			log.Infof("FlourAuthMiddleware: User %v has no flour role", r.Header.Get("X-Auth-User"))
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// OdooAuthMiddleware checks that the request carries the odoo role.
+func OdooAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// ignore for options request
+		if r.Method == "OPTIONS" {
+			next.ServeHTTP(w, r)
+			return // skip
+		}
+
+		if r.Header.Get("X-Auth-User-Validated") == "false" {
+			log.Info("OdooAuthMiddleware: No validated user", r.Header.Get("X-Auth-User"))
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if r.Header.Get("X-Auth-Roles-odoo") == "" {
+			log.Infof("OdooAuthMiddleware: User %v has no odoo role", r.Header.Get("X-Auth-User"))
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}

--- a/app/paymentprovider/vivawallet.go
+++ b/app/paymentprovider/vivawallet.go
@@ -349,17 +349,31 @@ func HandlePaymentSuccessfulResponse(paymentSuccessful TransactionSuccessRequest
 	// flour
 	if config.Config.FlourWebhookURL != "" {
 		log.Info("Flour Webhook set, sending webhook for order", order.ID)
-		// Send webhook to Flour
 		go func(id int, timestamp time.Time, items []database.OrderEntry, vendorID int, totalSum int) {
 			vendor, err := database.Db.GetVendor(vendorID)
 			if err != nil {
 				log.Error("Flour webhook: Getting vendor failed: ", err)
 				return
 			}
-
 			err = integrations.SendPaymentToFlour(id, timestamp, items, vendor, totalSum)
 			if err != nil {
 				log.Error("Sending payment to Flour failed: ", err)
+			}
+		}(order.ID, order.Timestamp, order.Entries, order.Vendor, int(sum))
+	}
+
+	// odoo
+	if config.Config.OdooWebhookURL != "" {
+		log.Info("Odoo Webhook set, sending webhook for order", order.ID)
+		go func(id int, timestamp time.Time, items []database.OrderEntry, vendorID int, totalSum int) {
+			vendor, err := database.Db.GetVendor(vendorID)
+			if err != nil {
+				log.Error("Odoo webhook: Getting vendor failed: ", err)
+				return
+			}
+			err = integrations.SendPaymentToOdoo(id, timestamp, items, vendor, totalSum)
+			if err != nil {
+				log.Error("Sending payment to Odoo failed: ", err)
 			}
 		}(order.ID, order.Timestamp, order.Entries, order.Vendor, int(sum))
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
       SENTRY_DSN: ${SENTRY_DSN}
       FLOUR_WEBHOOK_URL: ${FLOUR_WEBHOOK_URL}
       FLOUR_WEBHOOK_TOKEN: ${FLOUR_WEBHOOK_TOKEN}
+      ODOO_WEBHOOK_URL: ${ODOO_WEBHOOK_URL}
+      ODOO_WEBHOOK_TOKEN: ${ODOO_WEBHOOK_TOKEN}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docker/webhook-receiver/Dockerfile
+++ b/docker/webhook-receiver/Dockerfile
@@ -14,16 +14,29 @@ if (!fs.existsSync(logDir)) {
 }
 
 const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/logs") {
+    try {
+      const files = fs.readdirSync(logDir).filter(f => f.endsWith(".log")).sort();
+      const logs = files.map(f => fs.readFileSync(path.join(logDir, f), "utf8")).join("");
+      res.writeHead(200, {"Content-Type": "text/plain"});
+      res.end(logs || "(no webhooks received yet)");
+    } catch (e) {
+      res.writeHead(200, {"Content-Type": "text/plain"});
+      res.end("(no webhooks received yet)");
+    }
+    return;
+  }
+
   let body = "";
   req.on("data", chunk => { body += chunk; });
   req.on("end", () => {
     const timestamp = new Date().toISOString();
     const logFile = path.join(logDir, `webhooks-${new Date().toISOString().split("T")[0]}.log`);
     const logEntry = `[${timestamp}] ${req.method} ${req.url}\nHeaders: ${JSON.stringify(req.headers)}\nBody: ${body}\n\n`;
-    
+
     fs.appendFileSync(logFile, logEntry);
     console.log(`[${timestamp}] Webhook received: ${req.method} ${req.url}`);
-    
+
     res.writeHead(200, {"Content-Type": "application/json"});
     res.end(JSON.stringify({ status: "ok", received: timestamp }));
   });


### PR DESCRIPTION
Extracts the Odoo-specific behaviour (X-Odoo-Database header, Bearer token, 422-as-non-fatal, donation quantity collapsing, item Type field) into a new odoo.go integration and restores flour.go to its pre-Odoo state (commit 8e6ab48).

- flour.go / SendPaymentToFlour: legacy simple webhook, no Odoo headers
- odoo.go / SendPaymentToOdoo: Odoo-specific format with donation collapsing
- /api/flour route (FlourAuthMiddleware / X-Auth-Roles-flour): vendors + payments only
- /api/odoo route (OdooAuthMiddleware / X-Auth-Roles-odoo): vendors + payments + items
- vivawallet.go fires both independently based on FLOUR_WEBHOOK_URL / ODOO_WEBHOOK_URL
- ResendOdooWebhook resends to both configured endpoints
- docker-compose.yml exposes ODOO_WEBHOOK_URL and ODOO_WEBHOOK_TOKEN

# Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->
**IMPORTANT TO KNOW**
<!-- Let your reviewer know if she has to configure something new or somehting has to be thought further or ... -->

**CHANGES**
<!-- Let your reviewer know what changes happened in this PR ... -->

**TODO**
<!-- Let your reviewer know if there is still something to do or has to be done in the future i.e. for fine-tuning ... -->


# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works